### PR TITLE
fix: building project-test instead main library

### DIFF
--- a/src/Cardano/PTT/CLI/Embedded/shell-wrapper.sh
+++ b/src/Cardano/PTT/CLI/Embedded/shell-wrapper.sh
@@ -23,7 +23,7 @@ echo "Current PATH: $$PATH"
 
 # Execute cabal commands
 echo "Running cabal build..."
-cabal build escrow
+cabal build escrow-test
 
 
 echo "Running cabal test..."


### PR DESCRIPTION
## Description

in the shell script we should build the test project instead of the library :
`cabal build project-test` vs of `cabal build project`

