### PR TITLE
feat: discover test-suite within cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle/
 .vim/
 temp-notes.md
 todo.md
+cabal.project.local

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,7 +7,9 @@ import Options.Applicative
 main :: IO ()
 main = do
   args <- execParser argsInfo
-  let ctx = Ctx (verbose args) (projectPath args)
-  case cmd args of
-    CmdRunTests target -> runAllTests ctx (Just target)
-    CmdListTests -> listAllTests ctx
+  let ctx = Ctx (verbose args) (projectPath args) (sourceRelativePath args)
+  let exe = case cmd args of
+        CmdRunTests target -> runAllTests (Just target)
+        CmdListTests -> listAllTests
+        CmdShowTestSuite -> showTestSuite
+  exe ctx

--- a/ptt-cli.cabal
+++ b/ptt-cli.cabal
@@ -41,7 +41,7 @@ library
                      , aeson
                      , bytestring
                      , regex-tdfa
-                     -- , filepath
+                     , filepath
 
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/src/Cardano/PTT/CLI/Arguments.hs
+++ b/src/Cardano/PTT/CLI/Arguments.hs
@@ -6,6 +6,7 @@ data Args = Args
   { projectPath :: !FilePath
   , verbose :: !Bool
   , cmd :: !Command
+  , sourceRelativePath :: !(Maybe FilePath)
   }
 
 argsParser :: Parser Args
@@ -27,6 +28,15 @@ argsParser =
           <> showDefault
       )
     <*> commandParser
+    <*> optional
+      ( option
+          str
+          ( long "source-relative-path"
+              <> metavar "SOURCE_RELATIVE_PATH"
+              <> short 's'
+              <> help "Source relative path"
+          )
+      )
 
 argsInfo :: ParserInfo Args
 argsInfo =
@@ -37,13 +47,14 @@ argsInfo =
     )
 data TestTarget = TestTargetSingleTest String | TestTargetPattern String | TestTargetAllTests
 
-data Command = CmdListTests | CmdRunTests TestTarget
+data Command = CmdListTests | CmdRunTests TestTarget | CmdShowTestSuite
 
 commandParser :: Parser Command
 commandParser =
   hsubparser
     ( command "run-tests" (CmdRunTests <$> runTestsCommandInfo)
         <> command "list-tests" (CmdListTests <$ listTestsCommandInfo)
+        <> command "show-test-suite" (CmdShowTestSuite <$ listTestsCommandInfo)
     )
 
 listTestsCommandInfo :: ParserInfo ()
@@ -52,6 +63,14 @@ listTestsCommandInfo =
     (pure ())
     ( fullDesc
         <> header "ptt-cli list-tests — List all tests"
+    )
+
+showTestSuiteCommandInfo :: ParserInfo ()
+showTestSuiteCommandInfo =
+  info
+    (pure ())
+    ( fullDesc
+        <> header "ptt-cli show-test-suite — Show test suite name"
     )
 runTestsParser :: Parser TestTarget
 runTestsParser =

--- a/src/Cardano/PTT/CLI/Embedded/list-tests.sh
+++ b/src/Cardano/PTT/CLI/Embedded/list-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+NIX_PROJECT_PATH="$projectPath"
+cd $$NIX_PROJECT_PATH
+
+# Find the first .cabal file in the current directory
+CABAL_FILE=$(find . -maxdepth 1 -name "*.cabal" | head -n 1)
+
+# Check if a .cabal file was found
+if [[ -z "$$CABAL_FILE" ]]; then
+    echo "Error: No .cabal file found in the current directory."
+    exit 1
+fi
+
+# Extract names of executables and test suites
+TEST_SUITES=$(grep -E '^test-suite ' "$$CABAL_FILE" | sed 's/^test-suite //')
+
+
+# Count the number of test suites
+TEST_SUITE_COUNT=$(echo "$$TEST_SUITES" | wc -l)
+
+# Check if there is exactly one test suite
+if [[ "$$TEST_SUITE_COUNT" -eq 0 ]]; then
+    echo "Error: No test suites found in $$CABAL_FILE."
+    exit 1
+elif [[ "$$TEST_SUITE_COUNT" -gt 1 ]]; then
+    echo "Error: More than one test suite found in $$CABAL_FILE."
+    exit 1
+else
+    echo "$$TEST_SUITES"
+fi

--- a/src/Cardano/PTT/CLI/Embedded/shell-wrapper.sh
+++ b/src/Cardano/PTT/CLI/Embedded/shell-wrapper.sh
@@ -18,16 +18,18 @@ if ! command -v cabal &> /dev/null; then
     exit 1
 fi
 
+cd $sourcePath
 # Print current PATH for debugging
 echo "Current PATH: $$PATH"
+echo "Current folder: $(pwd)"
 
 # Execute cabal commands
 echo "Running cabal build..."
-cabal build escrow-test
-
+echo "cabal build $testSuite"
+cabal build $testSuite
 
 echo "Running cabal test..."
-# cabal run escrow-test # -- -l
+echo "$testExeLine"
 echo ">>>>>START"
 $testExeLine
 echo "<<<<<<END"


### PR DESCRIPTION
## Description

- list `test-suite` from cabal file
- add posibility for splitting project path (.flake location) from source path (.cabal file location)
- remove `escrow-test` hardcoding
- add some extra information in the verbose mode
- add `show-test-suite` as a command to the `ptt-cli`

Fixes #7 
