### PR TITLE
feat/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ temp-notes.md
 todo.md
 cabal.project.local
 test.json
+result

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle/
 temp-notes.md
 todo.md
 cabal.project.local
+test.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
    3.2 `cabal run ptt-cli -- --project-path=<MINIMAL_EXAMPLES_PATH>  list-tests`
 
+NOTE: now the repo supports nix develop env as well, so you can `nix develop .`
+
 Running the tests:
 
 all tests
@@ -31,3 +33,8 @@ eg: `cabal run ptt-cli -- --project-path=/Users/.../iog/minimal-ptt-examples-new
 multiple tests based on a pattern
 
 eg: `cabal run ptt-cli -- --project-path=/Users/.../iog/minimal-ptt-examples-new  run-tests --pattern "can redeem"`
+
+4. JSON tips
+
+   4.1 `CoverageStatus` possible values: "NotCovered", "HasBeenHere", "HasBeenFalse", "HasBeenTrue", "HasBeenBoth"
+   4.2 `IgnoreStatus` possible values: "NotIgnored", "IgnoredIfFalse", "IgnoredIfTrue", "AlwaysIgnored"

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,72 @@
+-- NOTE: we keep the commented out sections for reference for a while, but they will be removed eventually.
+packages: .
+
+-- Custom repository for cardano haskell packages
+-- See https://github.com/input-output-hk/cardano-haskell-packages on how to use CHaP in a Haskell project.
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+-- See CONTRIBUTING.adoc for how to update index-state
+index-state:
+  , hackage.haskell.org 2024-06-12T10:10:17Z
+  , cardano-haskell-packages 2024-06-12T10:10:17Z
+
+-- source-repository-package
+--   type: git
+--   location: https://github.com/IntersectMBO/cardano-node-emulator.git
+--   tag: 4e448248122cece3238052b3639eb4c0c36b422d
+--   --sha256: sha256-sB5pfwHm+r5z8gmePFogNoyFxKPR1TVVb2J8HQ7Eq1I=
+--   subdir: plutus-ledger
+--           plutus-script-utils
+--           cardano-node-emulator
+--           cardano-node-socket-emulator
+--           freer-extras
+
+-- We never, ever, want this.
+write-ghc-environment-files: never
+
+-- Always build tests and benchmarks.
+tests: true
+benchmarks: true
+
+-- The only sensible test display option, since it allows us to have colourized
+-- 'tasty' output.
+test-show-details: direct
+
+-- These packages appear in our dependency tree and are very slow to build.
+-- Empirically, turning off optimization shaves off ~50% build time.
+-- It also mildly improves recompilation avoidance.
+-- For dev work we don't care about performance so much, so this is okay.
+-- package cardano-ledger-alonzo
+--   optimization: False
+-- package ouroboros-consensus-cardano
+--   optimization: False
+-- package cardano-api
+--   optimization: False
+-- package cardano-crypto-praos
+--   flags: -external-libsodium-vrf
+
+-- -- This is quickcheck-contractmodel's HEAD of the Conway branch:
+-- -- https://github.com/input-output-hk/quickcheck-contractmodel/tree/Conway
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/quickcheck-contractmodel
+--     tag: b19a7689a0d40ba3c7f91da87ef5fbcf20f3926c
+--     --sha256: sha256-ronNW9uJoleclzLjRJhDWdWd9Dso2XSnUl4m3/2eb2k=
+--     subdir:
+--       quickcheck-contractmodel
+--       quickcheck-threatmodel
+
+-- source-repository-package
+--     type: git
+--     location: https://github.com/Ali-Hill/plutus-contract-certification-node
+--     tag: 945acad6ac294cb801d901fb4df851d9f2ca3106
+--     --sha256: sha256-keiXJeCCAPmVNlBlrg9uDUEjuEFCPAsZ2kHVdycrIPU=

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,1096 @@
+{
+  "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733946732,
+        "narHash": "sha256-8RwIGx4z0LELkL5d8Xg85/O5yqox6mHtusrNoIqSeCU=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-haskell-packages",
+        "rev": "6d857b7864e15267825582b785a6b1ce71942c1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.11",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "easy-purescript-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
+      "locked": {
+        "lastModified": 1710161569,
+        "narHash": "sha256-lcIRIOFCdIWEGyKyG/tB4KvxM9zoWuBRDxW+T+mvIb0=",
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "117fd96acb69d7d1727df95b6fde9d8715e031fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "iogx",
+          "pre-commit-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733963387,
+        "narHash": "sha256-jvsFZ+VbYB/hEqNuX9px8mH8xfoY4VAHZV9+VXcz/0w=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5c0fd51259ba86b2f81fe9d97f6dc09ebc7f5cf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskell-nix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": [
+          "hackage"
+        ],
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1733964714,
+        "narHash": "sha256-POXctrSvUhIIfFnLVSnNYF/fOOUiKNHFsGXkdm4luXE=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "04202f7e724a5fb61049fba3b37dda38245c3cdb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "iogx": {
+      "inputs": {
+        "CHaP": [
+          "CHaP"
+        ],
+        "easy-purescript-nix": "easy-purescript-nix",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "hackage": [
+          "hackage"
+        ],
+        "haskell-nix": [
+          "haskell-nix"
+        ],
+        "iohk-nix": "iohk-nix",
+        "nix2container": "nix2container",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "sphinxcontrib-haddock": "sphinxcontrib-haddock"
+      },
+      "locked": {
+        "lastModified": 1733738060,
+        "narHash": "sha256-uZZB/JE7ED7QWfsj9UOQriu3E5kDCtgWMvLCVujnqAo=",
+        "owner": "input-output-hk",
+        "repo": "iogx",
+        "rev": "507209c0acf0aaf607626d73b1711ea0afde7108",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iogx",
+        "type": "github"
+      }
+    },
+    "iohk-nix": {
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "iogx",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
+      "locked": {
+        "lastModified": 1732287300,
+        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1730479402,
+        "narHash": "sha256-79NLeNjpCa4mSasmFsE3QA6obURezF0TUO5Pm+1daog=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "5fb215a1564baa74ce04ad7f903d94ad6617e17a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1729242558,
+        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1712920918,
+        "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "92323443a56f4e9fc4e4b712e3119f66d0969297",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "CHaP": "CHaP",
+        "hackage": "hackage",
+        "haskell-nix": "haskell-nix",
+        "iogx": "iogx",
+        "nixpkgs": [
+          "haskell-nix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "sphinxcontrib-haddock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1594136664,
+        "narHash": "sha256-O9YT3iCUBHP3CEF88VDLLCO2HSP3HqkNA2q2939RnVY=",
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "rev": "f3956b3256962b2d27d5a4e96edb7951acf5de34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "type": "github"
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733962341,
+        "narHash": "sha256-KEYcuvkQKSk0SenzmhjHdDgjlGe9/5NGXBkuK4n/4MU=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "edde297076c748e14832f7cb615f0e754c359133",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#31-flakenix
+
+{
+  description = "PTT CLI";
+
+
+  inputs = {
+
+    iogx = {
+      url = "github:input-output-hk/iogx";
+      inputs.hackage.follows = "hackage";
+      inputs.CHaP.follows = "CHaP";
+      inputs.haskell-nix.follows = "haskell-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.follows = "haskell-nix/nixpkgs";
+
+    hackage = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+
+    CHaP = {
+      url = "github:IntersectMBO/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
+
+    haskell-nix = {
+      url = "github:input-output-hk/haskell.nix";
+      inputs.hackage.follows = "hackage";
+    };
+
+    # Used to provide the cardano-node and cardano-cli executables.
+    # cardano-node = {
+    #   url = "github:input-output-hk/cardano-node?ref=8.8.0-pre";
+    # };
+
+    # mithril = {
+    #   url = "github:input-output-hk/mithril";
+    # };
+  };
+
+
+  outputs = inputs: inputs.iogx.lib.mkFlake {
+    inherit inputs;
+    repoRoot = ./.;
+    systems = [ "x86_64-darwin" "x86_64-linux" "aarch64-darwin" ];
+    outputs = import ./nix/outputs.nix;
+  };
+
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.iog.io"
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+    allow-import-from-derivation = true;
+    accept-flake-config = true;
+  };
+}

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -1,0 +1,12 @@
+{ repoRoot, inputs, pkgs, lib, system }:
+
+let
+
+  project = repoRoot.nix.project;
+
+in
+[
+  (
+    project.flake
+  )
+]

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,0 +1,44 @@
+{ repoRoot, inputs, pkgs, system, lib }:
+
+let
+
+  cabalProject' = pkgs.haskell-nix.cabalProject' ({ pkgs, config, ... }:
+    let
+      # When `isCross` is `true`, it means that we are cross-compiling the project.
+      # WARNING You must use the `pkgs` coming from cabalProject' for `isCross` to work.
+      isCross = pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform;
+    in
+    {
+      name = "ptt-cli";
+
+      src = ../.;
+
+      shell.withHoogle = false;
+
+      inputMap = {
+        "https://chap.intersectmbo.org/" = inputs.CHaP;
+      };
+
+      compiler-nix-name = lib.mkDefault "ghc96";
+
+      modules =
+        [
+          {
+            packages = { };
+          }
+        ];
+    });
+
+
+  cabalProject = cabalProject'.appendOverlays [ ];
+
+
+  # Docs for mkHaskellProject: https://github.com/input-output-hk/iogx/blob/main/doc/api.md#mkhaskellproject
+  project = lib.iogx.mkHaskellProject {
+    inherit cabalProject;
+    shellArgs = repoRoot.nix.shell;
+  };
+
+in
+
+project

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,68 @@
+{ repoRoot, inputs, pkgs, lib, system }:
+
+cabalProject:
+
+{
+  name = "nix-shell";
+
+  # prompt = null;
+
+  # welcomeMessage = null;
+
+  # packages = [];
+
+  # scripts = {};
+
+  # env = {};
+
+  # shellHook = "";
+
+  tools = {
+    # haskellCompilerVersion = cabalProject.args.compiler-nix-name;
+    # cabal-fmt = null;
+    # cabal-install = null;
+    # haskell-language-server = null;
+    # haskell-language-server-wrapper = null;
+    # fourmolu = null;
+    # hlint = null;
+    # stylish-haskell = null;
+    # ghcid = null;
+    # shellcheck = null;
+    # prettier = null;
+    # editorconfig-checker = null;
+    # nixpkgs-fmt = null;
+    # optipng = null;
+    # purs-tidy = null;
+  };
+
+  # preCommit = {
+  #   fourmolu.enable = true;
+  #   shellcheck.enable = true;
+  #   cabal-fmt.enable = true;
+  #   optipng.enable = true;
+  #   nixpkgs-fmt.enable = true;
+  # };
+
+  # preCommit = {
+  #   cabal-fmt.enable = false;
+  #   cabal-fmt.extraOptions = "";
+  #   stylish-haskell.enable = false;
+  #   stylish-haskell.extraOptions = "";
+  #   fourmolu.enable = false;
+  #   fourmolu.extraOptions = "";
+  #   hlint.enable = false;
+  #   hlint.extraOptions = "";
+  #   shellcheck.enable = false;
+  #   shellcheck.extraOptions = "";
+  #   prettier.enable = false;
+  #   prettier.extraOptions = "";
+  #   editorconfig-checker.enable = false;
+  #   editorconfig-checker.extraOptions = "";
+  #   nixpkgs-fmt.enable = false;
+  #   nixpkgs-fmt.extraOptions = "";
+  #   optipng.enable = false;
+  #   optipng.extraOptions = "";
+  #   purs-tidy.enable = false;
+  #   purs-tidy.extraOptions = "";
+  # };
+}

--- a/ptt-cli.cabal
+++ b/ptt-cli.cabal
@@ -19,16 +19,39 @@ extra-doc-files:    CHANGELOG.md
 extra-source-files: src/Cardano/PTT/CLI/Embedded/*
 default-extensions:   OverloadedRecordDot
 
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    LambdaCase
+    NamedFieldPuns
+    ScopedTypeVariables
+    StandaloneDeriving
 
-common warnings
-    ghc-options: -Wall
+  -- See Plutus Tx readme for why we need the following flags:
+  -- -fobject-code -fno-ignore-interface-pragmas and -fno-omit-interface-pragmas
+  ghc-options:
+    -Wall -Widentities -Wincomplete-record-updates -Wunused-packages
+    -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+    -Wredundant-constraints -fobject-code
+    -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
+    -fplugin-opt PlutusTx.Plugin:target-version=1.0.0
 
 library
-    import:           warnings
+    import:           lang
     exposed-modules:   Cardano.PTT.CLI.Process
                      , Cardano.PTT.CLI.Arguments
 
-    other-modules:   Cardano.PTT.CLI.Internal
+    other-modules:     Cardano.PTT.CLI.Internal
+                     , Cardano.PTT.CLI.Coverage
     build-depends:     base ^>=4.18.1.0
                      , process
                      , text
@@ -42,12 +65,14 @@ library
                      , bytestring
                      , regex-tdfa
                      , filepath
+                     , plutus-tx
+                     , containers
 
     hs-source-dirs:   src
     default-language: Haskell2010
 
 executable ptt-cli
-    import:           warnings
+    import:           lang
 
     main-is:          Main.hs
 
@@ -60,7 +85,7 @@ executable ptt-cli
     default-language: Haskell2010
 
 test-suite ptt-cli-test
-    import:           warnings
+    import:           lang
 
     default-language: Haskell2010
     type:             exitcode-stdio-1.0

--- a/ptt-cli.cabal
+++ b/ptt-cli.cabal
@@ -49,9 +49,9 @@ library
     import:           lang
     exposed-modules:   Cardano.PTT.CLI.Process
                      , Cardano.PTT.CLI.Arguments
+                     , Cardano.PTT.CLI.Coverage
 
     other-modules:     Cardano.PTT.CLI.Internal
-                     , Cardano.PTT.CLI.Coverage
     build-depends:     base ^>=4.18.1.0
                      , process
                      , text
@@ -91,8 +91,10 @@ test-suite ptt-cli-test
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
     main-is:          Main.hs
+    other-modules:    Coverage.Spec
     build-depends:
           base ^>=4.18.1.0
         , ptt-cli
         , tasty
         , tasty-hunit
+        , containers

--- a/src/Cardano/PTT/CLI/Coverage.hs
+++ b/src/Cardano/PTT/CLI/Coverage.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Cardano.PTT.CLI.Coverage (
+  CoverageEntry (..),
+  CoverageGroup (..),
+  flattenCoverage,
+  covEntryToCovLoc,
+  covEntryToAnnotation,
+  FlattenCoverage (..),
+)
+where
+
+import Data.Aeson
+import Data.Bifunctor (first)
+import Data.Foldable (foldl')
+import Data.Map (Map)
+
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+
+import PlutusTx.Coverage (
+  CovLoc (..),
+  CoverageAnnotation (CoverBool, CoverLocation),
+ )
+
+data CoverageGroup = CoverageGroup
+  { covered :: ![CoverageEntry]
+  , uncovered :: ![CoverageEntry]
+  , ignored :: ![CoverageEntry]
+  }
+  deriving (Show)
+
+instance ToJSON CoverageGroup where
+  toJSON CoverageGroup{..} =
+    object
+      [ "covered" .= covered
+      , "uncovered" .= uncovered
+      , "ignored" .= ignored
+      ]
+
+data CoverageEntry = CoverageEntry
+  { coveStartLineNo :: !Int
+  , coveEndLineNo :: !Int
+  , coveStartColumn :: !Int
+  , coveEndColumn :: !Int
+  , coveStatus :: !(Maybe Bool)
+  , coveFile :: !String
+  }
+  deriving (Show)
+
+instance ToJSON CoverageEntry where
+  toJSON CoverageEntry{..} =
+    object
+      [ "startLine" .= coveStartLineNo
+      , "endLine" .= coveEndLineNo
+      , "startColumn" .= coveStartColumn
+      , "endColumn" .= coveEndColumn
+      , "status" .= coveStatus
+      , "file" .= coveFile
+      ]
+
+-- NOTE: Statuses and their class instances are copied from the cardano-node-emulator
+-- since the project doesn't expose them.
+data CoverStatus = NotCovered | HasBeenHere | HasBeenFalse | HasBeenTrue | HasBeenBoth
+  deriving (Eq, Ord, Show)
+
+instance ToJSON CoverStatus where
+  toJSON NotCovered = "NotCovered"
+  toJSON HasBeenHere = "HasBeenHere"
+  toJSON HasBeenFalse = "HasBeenFalse"
+  toJSON HasBeenTrue = "HasBeenTrue"
+  toJSON HasBeenBoth = "HasBeenBoth"
+
+data IgnoreStatus = NotIgnored | IgnoredIfFalse | IgnoredIfTrue | AlwaysIgnored
+  deriving (Eq, Ord, Show)
+
+instance ToJSON IgnoreStatus where
+  toJSON NotIgnored = "NotIgnored"
+  toJSON IgnoredIfFalse = "IgnoredIfFalse"
+  toJSON IgnoredIfTrue = "IgnoredIfTrue"
+  toJSON AlwaysIgnored = "AlwaysIgnored"
+
+data Status = OnChain !CoverStatus !IgnoreStatus
+  deriving (Eq, Ord, Show)
+
+instance Semigroup CoverStatus where
+  HasBeenBoth <> _ = HasBeenBoth
+  _ <> HasBeenBoth = HasBeenBoth
+  HasBeenFalse <> HasBeenTrue = HasBeenBoth
+  HasBeenTrue <> HasBeenFalse = HasBeenBoth
+  HasBeenFalse <> _ = HasBeenFalse
+  _ <> HasBeenFalse = HasBeenFalse
+  HasBeenTrue <> _ = HasBeenTrue
+  _ <> HasBeenTrue = HasBeenTrue
+  HasBeenHere <> _ = HasBeenHere
+  _ <> HasBeenHere = HasBeenHere
+  NotCovered <> NotCovered = NotCovered
+
+instance Monoid CoverStatus where
+  mempty = NotCovered
+
+instance Semigroup IgnoreStatus where
+  AlwaysIgnored <> _ = AlwaysIgnored
+  _ <> AlwaysIgnored = AlwaysIgnored
+  IgnoredIfFalse <> IgnoredIfTrue = AlwaysIgnored
+  IgnoredIfTrue <> IgnoredIfFalse = AlwaysIgnored
+  IgnoredIfTrue <> _ = IgnoredIfTrue
+  _ <> IgnoredIfTrue = IgnoredIfTrue
+  IgnoredIfFalse <> _ = IgnoredIfFalse
+  _ <> IgnoredIfFalse = IgnoredIfFalse
+  NotIgnored <> NotIgnored = NotIgnored
+
+instance Monoid IgnoreStatus where
+  mempty = NotIgnored
+
+-- The Semigroup instance is used to combine swipes over identical ranges.
+instance Semigroup Status where
+  OnChain c i <> OnChain c' i' = OnChain (c <> c') (i <> i')
+
+instance ToJSON Status where
+  toJSON (OnChain c i) =
+    object
+      [ "cover" .= c
+      , "ignore" .= i
+      ]
+
+instance Monoid Status where
+  mempty = OnChain mempty mempty
+
+newtype FlattenCoverage = FlattenCoverage
+  { unFlattenCoverage :: Map CovLoc Status
+  }
+
+newtype InternalCovLoc = InternalCovLoc CovLoc
+
+-- same as entry
+instance ToJSON InternalCovLoc where
+  toJSON (InternalCovLoc (CovLoc{..})) =
+    object
+      [ "startLine" .= _covLocStartLine
+      , "endLine" .= _covLocEndLine
+      , "startColumn" .= _covLocStartCol
+      , "endColumn" .= _covLocEndCol
+      , "file" .= _covLocFile
+      ]
+newtype InternalLocStatusKeyPair = InternalLocStatusKeyPair
+  { unInternalLocStatusKeyPair :: (InternalCovLoc, Status)
+  }
+
+instance ToJSON InternalLocStatusKeyPair where
+  toJSON InternalLocStatusKeyPair{..} =
+    object
+      [ "position" .= fst unInternalLocStatusKeyPair
+      , "status" .= snd unInternalLocStatusKeyPair
+      ]
+
+instance ToJSON FlattenCoverage where
+  toJSON FlattenCoverage{..} = toJSON xs
+   where
+    xs =
+      map
+        (InternalLocStatusKeyPair . Data.Bifunctor.first InternalCovLoc)
+        (Map.toList unFlattenCoverage)
+
+flattenCoverage :: CoverageGroup -> FlattenCoverage
+flattenCoverage group = FlattenCoverage allAnnWithOneStatus
+ where
+  -- keep in mind that Annotation for the same portion of code might
+  -- appear multiple times because of different statuses
+  -- We are going to merge it later
+  uncoveredAnn = toAnnSet uncovered
+  coveredAnn = toAnnSet covered
+  ignoredAnn = Set.fromList $ map covEntryToAnnotation $ ignored group
+  allAnn = Set.union coveredAnn uncoveredAnn `Set.union` ignoredAnn
+  -- transform the list of CoverageEntry into a set of CoverageAnnotation
+  toAnnSet list = Set.fromList $ map covEntryToAnnotation $ list group
+
+  allAnnWithStatuses :: Map CovLoc [Status]
+  allAnnWithStatuses =
+    listToMap $ map (\ann -> (annLocation ann, status' ann)) $ Set.toList allAnn
+
+  mergeStatuses :: [Status] -> Status
+  mergeStatuses = foldl' (<>) mempty
+
+  allAnnWithOneStatus :: Map CovLoc Status
+  allAnnWithOneStatus = Map.map mergeStatuses allAnnWithStatuses
+
+  status' ann = OnChain (ifM c covS) (ifM i ignS)
+   where
+    i = Set.member ann ignoredAnn
+    c = Set.notMember ann uncoveredAnn
+    ifM False _ = mempty
+    ifM True m = m
+    covS = case ann of
+      CoverBool _ True -> HasBeenTrue
+      CoverBool _ False -> HasBeenFalse
+      CoverLocation{} -> HasBeenHere
+    ignS = case ann of
+      CoverBool _ True -> IgnoredIfTrue
+      CoverBool _ False -> IgnoredIfFalse
+      CoverLocation{} -> AlwaysIgnored
+
+listToMap :: forall k a. (Ord k) => [(k, a)] -> Map k [a]
+listToMap = foldl' g Map.empty
+ where
+  g :: Map k [a] -> (k, a) -> Map k [a]
+  g d (k, a) =
+    let h Nothing = Just [a]
+        h (Just xs) = Just (a : xs)
+     in Map.alter h k d
+
+-- TODO: TEST ME
+covEntryToCovLoc :: CoverageEntry -> CovLoc
+covEntryToCovLoc CoverageEntry{..} =
+  CovLoc coveFile coveStartLineNo coveEndLineNo coveStartColumn coveEndColumn
+
+-- TODO: TEST ME
+covEntryToAnnotation :: CoverageEntry -> CoverageAnnotation
+covEntryToAnnotation entry@CoverageEntry{..} =
+  let covLoc = covEntryToCovLoc entry
+   in case coveStatus of
+        Just bool -> CoverBool covLoc bool
+        Nothing -> CoverLocation $ covEntryToCovLoc entry
+
+annLocation :: CoverageAnnotation -> CovLoc
+annLocation (CoverLocation loc) = loc
+annLocation (CoverBool loc _) = loc

--- a/src/Cardano/PTT/CLI/Coverage.hs
+++ b/src/Cardano/PTT/CLI/Coverage.hs
@@ -8,6 +8,11 @@ module Cardano.PTT.CLI.Coverage (
   covEntryToCovLoc,
   covEntryToAnnotation,
   FlattenCoverage (..),
+  CovLoc (..),
+  CoverageAnnotation (CoverBool, CoverLocation),
+  Status (..),
+  CoverStatus (..),
+  IgnoreStatus (..),
 )
 where
 
@@ -131,6 +136,7 @@ instance Monoid Status where
 newtype FlattenCoverage = FlattenCoverage
   { unFlattenCoverage :: Map CovLoc Status
   }
+  deriving (Show, Eq)
 
 newtype InternalCovLoc = InternalCovLoc CovLoc
 

--- a/test/Coverage/Spec.hs
+++ b/test/Coverage/Spec.hs
@@ -1,0 +1,263 @@
+module Coverage.Spec where
+
+import Cardano.PTT.CLI.Coverage
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.Map qualified as Map
+
+coverageTests :: TestTree
+coverageTests =
+  testGroup
+    "flattenCoverage tests"
+    [ testCase "covered with all the statuses" $
+        let actual = flattenCoverage $ CoverageGroup covered [] []
+             where
+              covered =
+                [ CoverageEntry 1 1 2 2 Nothing "f1"
+                , CoverageEntry 3 3 4 4 (Just True) "f1"
+                , CoverageEntry 5 5 6 6 (Just False) "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain HasBeenHere NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 3
+                            , _covLocEndLine = 3
+                            , _covLocStartCol = 4
+                            , _covLocEndCol = 4
+                            }
+                        , OnChain HasBeenTrue NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 5
+                            , _covLocEndLine = 5
+                            , _covLocStartCol = 6
+                            , _covLocEndCol = 6
+                            }
+                        , OnChain HasBeenFalse NotIgnored
+                        )
+                      ]
+                }
+         in actual @?= expected
+    , testCase "uncovered with all the statuses" $
+        let actual = flattenCoverage $ CoverageGroup [] uncovered []
+             where
+              uncovered =
+                [ CoverageEntry 1 1 2 2 Nothing "f1"
+                , CoverageEntry 3 3 4 4 (Just True) "f1"
+                , CoverageEntry 5 5 6 6 (Just False) "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain NotCovered NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 3
+                            , _covLocEndLine = 3
+                            , _covLocStartCol = 4
+                            , _covLocEndCol = 4
+                            }
+                        , OnChain NotCovered NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 5
+                            , _covLocEndLine = 5
+                            , _covLocStartCol = 6
+                            , _covLocEndCol = 6
+                            }
+                        , OnChain NotCovered NotIgnored
+                        )
+                      ]
+                }
+         in actual @?= expected
+    , testCase "non overlapped covered and uncovered" $
+        let actual = flattenCoverage $ CoverageGroup covered uncovered []
+             where
+              uncovered =
+                [ CoverageEntry 1 1 2 2 (Just True) "f1"
+                ]
+              covered =
+                [ CoverageEntry 3 3 4 4 (Just True) "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain NotCovered NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 3
+                            , _covLocEndLine = 3
+                            , _covLocStartCol = 4
+                            , _covLocEndCol = 4
+                            }
+                        , OnChain HasBeenTrue NotIgnored
+                        )
+                      ]
+                }
+         in actual @?= expected
+    , testCase "ignored with all the statuses" $
+        let actual = flattenCoverage $ CoverageGroup [] [] ignored
+             where
+              ignored =
+                [ CoverageEntry 1 1 2 2 Nothing "f1"
+                , CoverageEntry 3 3 4 4 (Just True) "f1"
+                , CoverageEntry 5 5 6 6 (Just False) "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain HasBeenHere AlwaysIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 3
+                            , _covLocEndLine = 3
+                            , _covLocStartCol = 4
+                            , _covLocEndCol = 4
+                            }
+                        , OnChain HasBeenTrue IgnoredIfTrue
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 5
+                            , _covLocEndLine = 5
+                            , _covLocStartCol = 6
+                            , _covLocEndCol = 6
+                            }
+                        , OnChain HasBeenFalse IgnoredIfFalse
+                        )
+                      ]
+                }
+         in actual @?= expected
+    , testCase "overlapped covered and uncovered" $
+        let actual = flattenCoverage $ CoverageGroup covered uncovered []
+             where
+              covered =
+                [ CoverageEntry 1 1 2 2 Nothing "f1"
+                , CoverageEntry 3 3 4 4 (Just True) "f1"
+                , CoverageEntry 5 5 6 6 (Just False) "f1"
+                ]
+              uncovered =
+                [ CoverageEntry 1 1 2 2 (Just False) "f1"
+                , CoverageEntry 3 3 4 4 Nothing "f1"
+                , CoverageEntry 5 5 6 6 Nothing "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain HasBeenHere NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 3
+                            , _covLocEndLine = 3
+                            , _covLocStartCol = 4
+                            , _covLocEndCol = 4
+                            }
+                        , OnChain HasBeenTrue NotIgnored
+                        )
+                      ,
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 5
+                            , _covLocEndLine = 5
+                            , _covLocStartCol = 6
+                            , _covLocEndCol = 6
+                            }
+                        , OnChain HasBeenFalse NotIgnored
+                        )
+                      ]
+                }
+         in actual @?= expected
+    , testCase "overlapped covered , uncovered, ignored" $
+        let actual = flattenCoverage $ CoverageGroup covered uncovered ignored
+             where
+              covered =
+                [ CoverageEntry 1 1 2 2 Nothing "f1"
+                ]
+              uncovered =
+                [ CoverageEntry 1 1 2 2 (Just False) "f1"
+                ]
+              ignored =
+                [ CoverageEntry 1 1 2 2 (Just False) "f1"
+                ]
+            expected =
+              FlattenCoverage
+                { unFlattenCoverage =
+                    Map.fromList
+                      [
+                        ( CovLoc
+                            { _covLocFile = "f1"
+                            , _covLocStartLine = 1
+                            , _covLocEndLine = 1
+                            , _covLocStartCol = 2
+                            , _covLocEndCol = 2
+                            }
+                        , OnChain HasBeenHere IgnoredIfFalse
+                        )
+                      ]
+                }
+         in actual @?= expected
+    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import Cardano.PTT.CLI.Process
+import Coverage.Spec (coverageTests)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -69,4 +70,5 @@ parseOutputLineTests =
           expected = (Nothing, Just $ fail'{testStatus = TestFail "first line\nsecond line"})
          in
           actual @?= expected
+    , coverageTests
     ]


### PR DESCRIPTION
## Description

Parse and add coverage to the `run-tests` result

Fixes #20 
Fixes #2  

Instructions:
- the output for `test-results` command has changed from an array of test results to an object embeding that list (`results` property) 
- to test the tool it should be used against `minimal-ptt-examples` on the branch `escrow-coverage` https://github.com/input-output-hk/minimal-ptt-examples/tree/escrow-coverage


