### PR TITLE
feat: pass testing options

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ main = do
   args <- execParser argsInfo
   let ctx = Ctx (verbose args) (projectPath args) (sourceRelativePath args)
   let exe = case cmd args of
-        CmdRunTests target -> runAllTests (Just target)
+        CmdRunTests runTestArgs -> runAllTests runTestArgs
         CmdListTests -> listAllTests
         CmdShowTestSuite -> showTestSuite
   exe ctx

--- a/src/Cardano/PTT/CLI/Arguments.hs
+++ b/src/Cardano/PTT/CLI/Arguments.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Cardano.PTT.CLI.Arguments where
 
 import Options.Applicative
@@ -47,7 +49,41 @@ argsInfo =
     )
 data TestTarget = TestTargetSingleTest String | TestTargetPattern String | TestTargetAllTests
 
-data Command = CmdListTests | CmdRunTests TestTarget | CmdShowTestSuite
+-- base on how escrow-test is used, we can infer the following arguments
+data RunTestsArguments = RunTestsArguments
+  { testTarget :: !TestTarget
+  , timeout :: !(Maybe String)
+  , testCoverage :: !Bool
+  , numThreads :: !(Maybe Int)
+  , minDurationToReport :: !(Maybe String)
+  , quickcheckTests :: !(Maybe Int)
+  , quickcheckReplay :: !(Maybe Int)
+  , quickcheckMaxSize :: !(Maybe Int)
+  , quickcheckMaxRatio :: !(Maybe Int)
+  , quickcheckShrinks :: !(Maybe Int)
+  }
+
+extractTestArgumentsForTestRun :: RunTestsArguments -> [String]
+extractTestArgumentsForTestRun RunTestsArguments{..} =
+  maybe [] (\x -> ["--timeout " ++ x]) timeout
+    ++ ["--test-coverage" | testCoverage]
+    ++ maybe [] (\x -> ["--num-threads " ++ show x]) numThreads
+    ++ maybe [] (\x -> ["--min-duration-to-report " ++ x]) minDurationToReport
+    ++ maybe [] (\x -> ["--quickcheck-tests " ++ show x]) quickcheckTests
+    ++ maybe [] (\x -> ["--quickcheck-replay " ++ show x]) quickcheckReplay
+    ++ maybe [] (\x -> ["--quickcheck-max-size " ++ show x]) quickcheckMaxSize
+    ++ maybe [] (\x -> ["--quickcheck-max-ratio " ++ show x]) quickcheckMaxRatio
+    ++ maybe [] (\x -> ["--quickcheck-shrinks " ++ show x]) quickcheckShrinks
+    ++ ( case testTarget of
+          (TestTargetSingleTest target) -> ["-p '\\$0==\"" ++ target ++ "\"'"]
+          (TestTargetPattern target) -> ["-p '" ++ target ++ "'"]
+          _otherwise -> []
+       )
+
+data Command
+  = CmdListTests
+  | CmdRunTests !RunTestsArguments
+  | CmdShowTestSuite
 
 commandParser :: Parser Command
 commandParser =
@@ -72,8 +108,130 @@ showTestSuiteCommandInfo =
     ( fullDesc
         <> header "ptt-cli show-test-suite — Show test suite name"
     )
-runTestsParser :: Parser TestTarget
-runTestsParser =
+
+runTestsArgumentsParser :: Parser RunTestsArguments
+runTestsArgumentsParser =
+  RunTestsArguments
+    -- based on escrow-test but without pattern which will be replaced
+    -- by testTarget
+    <$> runTestTargetParser
+    <*> timeoutParser
+    <*> testCoverageParser
+    <*> numThreadsParser
+    <*> minDurationToReportParser
+    <*> quickcheckTestsParser
+    <*> quickcheckReplayParser
+    <*> quickcheckMaxSizeParser
+    <*> quickcheckMaxRatioParser
+    <*> quickcheckShrinksParser
+
+quickcheckMaxSizeParser :: Parser (Maybe Int)
+quickcheckMaxSizeParser =
+  optional $
+    option
+      auto
+      ( long "quickcheck-max-size"
+          <> help "Size of the biggest test cases quickcheck generates"
+      )
+
+quickcheckMaxRatioParser :: Parser (Maybe Int)
+quickcheckMaxRatioParser =
+  optional $
+    option
+      auto
+      ( long "quickcheck-max-ratio"
+          <> help "Maximum number of discared tests per successful test before giving up"
+      )
+
+quickcheckShrinksParser :: Parser (Maybe Int)
+quickcheckShrinksParser =
+  optional $
+    option
+      auto
+      ( long "quickcheck-shrinks"
+          <> help "Number of shrinks allowed before QuickCheck will fail a test"
+      )
+
+quickcheckReplayParser :: Parser (Maybe Int)
+quickcheckReplayParser =
+  optional $
+    option
+      auto
+      ( long "quickcheck-replay"
+          <> help "Random seed to use for replaying a previous test run (use same --quickcheck-max-size)"
+      )
+
+quickcheckTestsParser :: Parser (Maybe Int)
+quickcheckTestsParser =
+  optional $
+    option
+      auto
+      ( long "quickcheck-tests"
+          <> help "Number of test cases for QuickCheck to generate. Underscores accepted: e.g. 10_000_000"
+      )
+
+minDurationToReportParser :: Parser (Maybe String)
+minDurationToReportParser =
+  optional $
+    option
+      auto
+      ( long "min-duration-to-report"
+          <> help
+            ( "The minimum amount of time a test can take before tasty prints timing information"
+                ++ " (suffixes: ms,s,m,h; default: s)"
+            )
+      )
+
+quietParser :: Parser (Maybe Bool)
+quietParser =
+  optional $
+    switch
+      ( long "quiet"
+          <> short 'q'
+          <> help "Do not produce any output; indicate success only by the exit code"
+      )
+
+numThreadsParser :: Parser (Maybe Int)
+numThreadsParser =
+  optional $
+    option
+      auto
+      ( long "num-threads"
+          <> short 'j'
+          <> help "Number of threads to use for tests execution (default: # of cores/capabilities)"
+      )
+
+testCoverageParser :: Parser Bool
+testCoverageParser =
+  flag
+    False
+    True
+    ( long "test-coverage"
+        <> short 'c'
+        <> help "Enable test coverage. Flag presence implies True."
+    )
+
+hideProgressParser :: Parser (Maybe Bool)
+hideProgressParser =
+  optional $
+    switch
+      ( long "hide-progress"
+          <> help "Do not show progress"
+      )
+
+timeoutParser :: Parser (Maybe String)
+timeoutParser =
+  optional $
+    option
+      str
+      ( long "timeout"
+          <> metavar "DURATION"
+          <> short 't'
+          <> help "Timeout for individual tests (suffixes: ms,s,m,h; default: s)"
+      )
+
+runTestTargetParser :: Parser TestTarget
+runTestTargetParser =
   (TestTargetSingleTest <$> testTargetSingleTestParser)
     <|> (TestTargetPattern <$> testTargetPatternParser)
     -- if nothing is provided, default to all tests
@@ -97,10 +255,10 @@ testTargetPatternParser =
         <> help "Run all tests matching a pattern"
     )
 
-runTestsCommandInfo :: ParserInfo TestTarget
+runTestsCommandInfo :: ParserInfo RunTestsArguments
 runTestsCommandInfo =
   info
-    runTestsParser
+    runTestsArgumentsParser
     ( fullDesc
         <> header "ptt-cli run-tests — Run all tests"
     )

--- a/src/Cardano/PTT/CLI/Coverage.hs
+++ b/src/Cardano/PTT/CLI/Coverage.hs
@@ -68,7 +68,7 @@ instance ToJSON CoverageEntry where
 -- NOTE: Statuses and their class instances are copied from the cardano-node-emulator
 -- since the project doesn't expose them.
 data CoverStatus = NotCovered | HasBeenHere | HasBeenFalse | HasBeenTrue | HasBeenBoth
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 instance ToJSON CoverStatus where
   toJSON NotCovered = "NotCovered"
@@ -78,7 +78,7 @@ instance ToJSON CoverStatus where
   toJSON HasBeenBoth = "HasBeenBoth"
 
 data IgnoreStatus = NotIgnored | IgnoredIfFalse | IgnoredIfTrue | AlwaysIgnored
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 instance ToJSON IgnoreStatus where
   toJSON NotIgnored = "NotIgnored"
@@ -87,7 +87,7 @@ instance ToJSON IgnoreStatus where
   toJSON AlwaysIgnored = "AlwaysIgnored"
 
 data Status = OnChain !CoverStatus !IgnoreStatus
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
 instance Semigroup CoverStatus where
   HasBeenBoth <> _ = HasBeenBoth
@@ -216,12 +216,10 @@ listToMap = foldl' g Map.empty
         h (Just xs) = Just (a : xs)
      in Map.alter h k d
 
--- TODO: TEST ME
 covEntryToCovLoc :: CoverageEntry -> CovLoc
 covEntryToCovLoc CoverageEntry{..} =
   CovLoc coveFile coveStartLineNo coveEndLineNo coveStartColumn coveEndColumn
 
--- TODO: TEST ME
 covEntryToAnnotation :: CoverageEntry -> CoverageAnnotation
 covEntryToAnnotation entry@CoverageEntry{..} =
   let covLoc = covEntryToCovLoc entry


### PR DESCRIPTION
Fixes #9 

NOTE:

works just with https://github.com/input-output-hk/minimal-ptt-examples/pull/21 (the branch is in https://github.com/bogdan-manole/minimal-ptt-examples/tree/feat/testing-options )

for all available options use : 
`nix run .#ptt-cli -- run-tests -h ` or `cabal run ptt-cli-test -- -h`

```
ptt-cli run-tests — Run all tests

Usage: ptt-cli run-tests [--test TEST_NAME | --pattern PATTERN]
                         [-t|--timeout DURATION] [-c|--test-coverage]
                         [-j|--num-threads ARG] [--min-duration-to-report ARG]
                         [--quickcheck-tests ARG] [--quickcheck-replay ARG]
                         [--quickcheck-max-size ARG]
                         [--quickcheck-max-ratio ARG] [--quickcheck-shrinks ARG]

Available options:
  --test TEST_NAME         Run a single test
  --pattern PATTERN        Run all tests matching a pattern
  -t,--timeout DURATION    Timeout for individual tests (suffixes: ms,s,m,h;
                           default: s)
  -c,--test-coverage       Enable test coverage. Flag presence implies True.
  -j,--num-threads ARG     Number of threads to use for tests execution
                           (default: # of cores/capabilities)
  --min-duration-to-report ARG
                           The minimum amount of time a test can take before
                           tasty prints timing information (suffixes: ms,s,m,h;
                           default: s)
  --quickcheck-tests ARG   Number of test cases for QuickCheck to generate.
                           Underscores accepted: e.g. 10_000_000
  --quickcheck-replay ARG  Random seed to use for replaying a previous test run
                           (use same --quickcheck-max-size)
  --quickcheck-max-size ARG
                           Size of the biggest test cases quickcheck generates
  --quickcheck-max-ratio ARG
                           Maximum number of discared tests per successful test
                           before giving up
  --quickcheck-shrinks ARG Number of shrinks allowed before QuickCheck will fail
                           a test
  -h,--help                Show this help text
  ```